### PR TITLE
Scope the styling of the stamp button

### DIFF
--- a/src/components/CreateStamp.js
+++ b/src/components/CreateStamp.js
@@ -70,7 +70,10 @@ class CreateStamp extends Component {
                 name: 'timezone'
               }}
             />
-            <button onClick={showZonestampLink}>Generate Stamp!</button>
+            <button
+              className="stamp-generate"
+              onClick={showZonestampLink}>Generate Stamp!
+            </button>
             <div id="stamp-link-wrapper" style={{ display: 'none' }}>
               <div className="arrow-up" />
               <div className="stamp-link">

--- a/src/css/CreateStamp.scss
+++ b/src/css/CreateStamp.scss
@@ -17,7 +17,7 @@
   }
 }
 
-button {
+.stamp-generate {
   color: #0896b9;
   box-shadow: none;
   font-size: 1.5rem;


### PR DESCRIPTION
The timezonepicker also uses buttons inside the drowdown list and
the CSS of the createstamp button was bleeding into it