### PR TITLE
Avoid usage of jsx generated classname

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import Header from './Header';
 import Footer from './Footer';
 import '../css/App.scss';
-import '../css/timezone-picker.scss';
 import '../css/footer.scss';
 
 class App extends Component {

--- a/src/components/CreateStamp.js
+++ b/src/components/CreateStamp.js
@@ -9,6 +9,7 @@ import 'moment-timezone';
 import 'react-datepicker/dist/react-datepicker.css';
 import '../css/CreateStamp.scss';
 import '../css/DatepickerPortal.scss';
+import '../css/timezone-picker.scss';
 
 class CreateStamp extends Component {
   state = {

--- a/src/components/StampDisplay.js
+++ b/src/components/StampDisplay.js
@@ -4,6 +4,7 @@ import TimezonePicker from 'react-timezone';
 import Moment from 'react-moment';
 import 'moment-timezone';
 import '../css/DisplayStamp.scss';
+import '../css/timezone-picker.scss';
 
 class StampDisplay extends Component {
   state = {

--- a/src/css/timezone-picker.scss
+++ b/src/css/timezone-picker.scss
@@ -1,4 +1,4 @@
-.timezone-picker.jsx-693531783 {
+.timezone-picker.timezone-picker {
   min-width: 250px;
   font-size: 1rem;
   font-family: 'Quicksand', sans-serif;


### PR DESCRIPTION
Use double classname instead to raise the specificty of our overrides