### PR TITLE
Use ISO 8601 format for UTC time

### DIFF
--- a/src/components/StampDisplay.js
+++ b/src/components/StampDisplay.js
@@ -54,7 +54,7 @@ class StampDisplay extends Component {
             />
             <div className="time-utc">
               <p>or</p>
-              <Moment tz="UTC" format="DD-MM-YYYY hh:mm z" unix>
+              <Moment tz="UTC" format="YYYY-MM-DD HH:mm z" unix>
                   {this.state.date}
               </Moment>
             </div>


### PR DESCRIPTION
Use YYYY-MM-DD for date and 24 hour clock for time when displaying UTC variant.

Per https://xkcd.com/1179/ this is the one true way to write numeric dates. :)