### PR TITLE
Add calendar button

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "add-to-calendar-button": "^1.14.3",
     "gh-pages": "^2.0.1",
     "moment": "^2.29.3",
     "moment-timezone": "^0.5.34",

--- a/src/components/StampDisplay.js
+++ b/src/components/StampDisplay.js
@@ -3,17 +3,50 @@ import App from './App';
 import TimezoneSelect from 'react-timezone-select'
 import Moment from 'react-moment';
 import moment from 'moment-timezone';
+import { atcb_init } from 'add-to-calendar-button';
 import 'moment-timezone';
 import '../css/DisplayStamp.scss';
 import '../css/timezone-picker.scss';
+import 'add-to-calendar-button/assets/css/atcb.css';
+
+const params = new URLSearchParams(window.location.search);
+const datestamp = parseInt( window.location.pathname.substr(1), 10 );
 
 class StampDisplay extends Component {
   state = {
     zoneName: Intl.DateTimeFormat().resolvedOptions().timeZone,
-    date: parseInt( window.location.pathname.substr(1), 10 ),
     zone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-    format: moment.localeData().longDateFormat('LT')
+    format: moment.localeData().longDateFormat('LT'),
+    date: datestamp,
+    enddate: params.has('enddate') ? parseInt( params.get('enddate'), 10 ) : datestamp + 3600,
+    name: params.get('name') || null,
+    description: params.get('description') || null,
+    location: params.get('location') || null,
+
   };
+  atcbConfig = {
+    name: this.state.name,
+    description: this.state.description,
+    startDate: moment.unix(this.state.date).format('YYYY-MM-DD'),
+    endDate: moment.unix(this.state.enddate).format('YYYY-MM-DD'),
+    startTime: moment.unix(this.state.date).format('HH:mm'),
+    endTime: moment.unix(this.state.enddate).format('HH:mm'),
+    location: this.state.location,
+    options: [
+      'iCal',
+      'Google',
+      'Apple',
+      'Microsoft365',
+      'MicrosoftTeams',
+      'Outlook.com',
+      'Yahoo',
+    ],
+  };
+  componentDidMount() {
+    if ( this.atcbConfig.name ) {
+      atcb_init();
+    }
+  }
   changeFormat = () => {
     if (this.state.format === 'h:mm a' || this.state.format === 'h:mm A') {
       this.setState({ format: 'HH:mm' });
@@ -57,6 +90,9 @@ class StampDisplay extends Component {
               <Moment tz="UTC" format="YYYY-MM-DD HH:mm z" unix>
                   {this.state.date}
               </Moment>
+            </div>
+            <div className="atcb">
+              {JSON.stringify(this.atcbConfig, null, 4)}
             </div>
           </Fragment>
         }


### PR DESCRIPTION
Adds a calendar button using [add2cal/add-to-calendar-button](https://github.com/add2cal/add-to-calendar-button) which shows up when there is a 'name' URL query parameter defining the event name. Other possible parameters: 'enddate' (a UNIX timestamp), 'description', 'location'.

Issue: #6