### PR TITLE
Improve constrast

### DIFF
--- a/src/components/CreateStamp.js
+++ b/src/components/CreateStamp.js
@@ -25,6 +25,14 @@ class CreateStamp extends Component {
         button.style.display = 'none';
       }
     }
+    // Style to improve contrast of dropdown indicator and "no options" message
+    const style = {
+      dropdownIndicator: (base, state) => ({
+        ...base,
+        color: state.isFocused ? 'white' : 'silver'
+      }),
+      noOptionsMessage: (base) => ({ ...base, color: 'white' })
+    };
     return (
       <App
         main={
@@ -62,6 +70,7 @@ class CreateStamp extends Component {
               className="timezone-picker"
               classNamePrefix="timezone-picker-select"
               value={this.state.zone}
+              styles={style}
               onChange={timezone => {
                 let newStartDate = this.state.startDate.tz(timezone.value, true);
                 this.setState({

--- a/src/css/App.scss
+++ b/src/css/App.scss
@@ -3,7 +3,7 @@
 }
 
 body {
-  background-color: #0896b9;
+  background-color: #0c7fa2;
   font-family: 'Quicksand', sans-serif;
   color: #fff;
 }

--- a/src/css/App.scss
+++ b/src/css/App.scss
@@ -61,3 +61,7 @@ main {
   font-family: 'Lobster', cursive;
   letter-spacing: 1px;
 }
+
+.attribution {
+  line-height: 1.6;
+}

--- a/src/css/CreateStamp.scss
+++ b/src/css/CreateStamp.scss
@@ -25,7 +25,7 @@ main p {
   font-size: 1.5rem;
   padding: 1rem;
   border: none;
-  background-color: rgba(255, 255, 255, 0.8);
+  background-color: rgba(255, 255, 255, 0.9);
   border-radius: 3px;
   font-family: 'Lobster', cursive;
   margin: 2rem 1rem 0;

--- a/src/css/timezone-picker.scss
+++ b/src/css/timezone-picker.scss
@@ -26,4 +26,7 @@
     background-color: #fff;
     color: #0896b9;
   }
+  .timezone-picker-select__dropdown-indicator:hover {
+    color: white;
+  }
 }


### PR DESCRIPTION
While using the app in low-visibility environments (e.g. outside in direct sunlight) I had trouble reading some of the text.
Indeed, the WCAG checks indicate a contrast of 3.46 to 1, whereas the recommended minimum contrast is of 4.5 to 1.

I have slightly tweaked the colors in various places, just enough to meet the contrast recommendations but otherwise remaining as close as possible to the current colors.

In addition, I added a separate commit increasing the line height of the attribution text, which was too cramped before. 

| Before | After |
| ------ | ----- |
| ![image](https://github.com/hartman/zonestamp/assets/478237/aede3883-e9a6-45e7-93be-defffd3c46f4) | ![image](https://github.com/hartman/zonestamp/assets/478237/f3785db4-d6d2-49db-8b0d-cd347dae2bda) |
| ![image](https://github.com/hartman/zonestamp/assets/478237/5c920b14-68b9-4183-9af8-1390e7101ee3) | ![image](https://github.com/hartman/zonestamp/assets/478237/b6e96d2a-ce40-4e51-b624-2961f59e8823) |

Many thanks to @hugopeixoto for the help in the React part! Also, I should point out that this change was implemented as part of the Wikimedia hackathon at the [2023 Free Software Fest](https://festa2023.softwarelivre.eu) in Aveiro, Portugal :)
