### PR TITLE
Use a more international date format

### DIFF
--- a/src/components/CreateStamp.js
+++ b/src/components/CreateStamp.js
@@ -40,7 +40,7 @@ class CreateStamp extends Component {
                   onChange={date => {
                     this.setState({ startDate: date.tz(this.state.zoneName) });
                   }}
-                  dateFormat="MMMM DD, YYYY"
+                  dateFormat="DD MMMM YYYY"
                   withPortal
                 />
               </div>

--- a/src/components/StampDisplay.js
+++ b/src/components/StampDisplay.js
@@ -85,7 +85,7 @@ class StampDisplay extends Component {
               onClick={this.changeFormat}>24h / 12h
             </button>
             <div className="time-day">
-              <Moment tz={this.state.zoneName} format="dddd, MMMM Do YYYY" unix>
+              <Moment tz={this.state.zoneName} format="dddd, DD MMMM YYYY" unix>
                 {this.state.date}
               </Moment>
             </div>


### PR DESCRIPTION
MDY is primarily used in the USA. DMY, in contrast, is used by the majority of the world: <https://en.wikipedia.org/wiki/Calendar_date>.

| Before | After |
| ------ | ----- |
| ![image](https://github.com/symbl-cc/symbl-data/assets/478237/17bdeb2b-3765-4f23-a6c6-1fd12e69ba01) | ![image](https://github.com/symbl-cc/symbl-data/assets/478237/efccbda9-c338-481c-94f4-687584a69d21) |
| ![image](https://github.com/hartman/zonestamp/assets/478237/6de40a98-c228-403d-a20c-cf5dbfd9d2e3) | ![image](https://github.com/hartman/zonestamp/assets/478237/9632cfe9-7bb8-46a7-9325-038db4022a11) |